### PR TITLE
Fix use-after-free in UMS Filesystem name/mount_name

### DIFF
--- a/src/fs/fs_common.hpp
+++ b/src/fs/fs_common.hpp
@@ -165,7 +165,7 @@ class Filesystem {
 
     public:
         Type type;
-        std::string_view name, mount_name;
+        std::string name, mount_name;
 
     protected:
         devoptab_t devoptab = {};

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -141,19 +141,25 @@ void ums_devices_changed_cb(const std::vector<sw::fs::UmsController::Device> &de
     auto &context = *static_cast<sw::Context *>(user);
 
     // Remove unmounted devices
-    for (auto &fs: context.filesystems) {
+    bool removed_cur = false;
+    std::erase_if(context.filesystems, [&](const auto &fs) {
         if (fs->type != sw::fs::Filesystem::Type::Usb)
-            continue;
+            return false;
 
         auto it = std::find_if(devices.begin(), devices.end(), [&fs](const auto &dev) {
             return fs->mount_name == dev.mount_name;
         });
 
         if (it == devices.end()) {
-            std::erase(context.filesystems, fs);
-            context.cur_fs = context.filesystems.front();
+            if (context.cur_fs == fs)
+                removed_cur = true;
+            return true;
         }
-    }
+        return false;
+    });
+
+    if (removed_cur && !context.filesystems.empty())
+        context.cur_fs = context.filesystems.front();
 
     // Add new devices
     for (auto &dev: devices) {

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -15,9 +15,12 @@
 // You should have received a copy of the GNU General Public License
 // along with SwitchWave.  If not, see <http://www.gnu.org/licenses/>.
 
+#include <cerrno>
 #include <cstdio>
 #include <chrono>
 #include <filesystem>
+#include <mutex>
+#include <optional>
 #include <string_view>
 #include <thread>
 
@@ -137,8 +140,26 @@ void mpv_presetup() {
     std::printf("Dumped standard font\n");
 }
 
+// libusbhsfs invokes the populate callback on its USB-event thread.
+// Stash the new device list under a mutex; the main thread applies
+// the change so context.filesystems / cur_fs stay single-threaded.
+std::mutex                                              g_ums_pending_mtx;
+std::optional<std::vector<sw::fs::UmsController::Device>> g_ums_pending;
+
 void ums_devices_changed_cb(const std::vector<sw::fs::UmsController::Device> &devices, void *user) {
-    auto &context = *static_cast<sw::Context *>(user);
+    auto lk = std::scoped_lock(g_ums_pending_mtx);
+    g_ums_pending = devices;
+}
+
+void apply_pending_ums_changes(sw::Context &context) {
+    std::vector<sw::fs::UmsController::Device> devices;
+    {
+        auto lk = std::scoped_lock(g_ums_pending_mtx);
+        if (!g_ums_pending)
+            return;
+        devices = std::move(*g_ums_pending);
+        g_ums_pending.reset();
+    }
 
     // Remove unmounted devices
     bool removed_cur = false;
@@ -186,6 +207,8 @@ int menu_loop(sw::Renderer &renderer, sw::Context &context) {
             context.want_quit = true;
             break;
         }
+
+        apply_pending_ums_changes(context);
 
         padUpdate(&g_pad);
         auto has_touches = hidGetTouchScreenStates(&g_touch_state, 1);
@@ -280,6 +303,18 @@ int video_loop(sw::Renderer &renderer, sw::Context &context) {
     while (!context.want_quit && !context.player_is_idle && !context.last_error) {
         if (!appletMainLoop()) {
             context.want_quit = true;
+            break;
+        }
+
+        apply_pending_ums_changes(context);
+
+        // If the filesystem hosting the playing file was unplugged
+        // (e.g. USB key removed mid-playback), stop mpv and bail out
+        // of the player loop so it can't keep reading a dead device.
+        if (!context.cur_file.empty() &&
+                !context.get_filesystem(sw::fs::Path::mountpoint(context.cur_file))) {
+            lmpv.command_async("stop");
+            context.set_error(-EIO);
             break;
         }
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -143,7 +143,7 @@ void mpv_presetup() {
 // libusbhsfs invokes the populate callback on its USB-event thread.
 // Stash the new device list under a mutex; the main thread applies
 // the change so context.filesystems / cur_fs stay single-threaded.
-std::mutex                                              g_ums_pending_mtx;
+std::mutex                                                g_ums_pending_mtx;
 std::optional<std::vector<sw::fs::UmsController::Device>> g_ums_pending;
 
 void ums_devices_changed_cb(const std::vector<sw::fs::UmsController::Device> &devices, void *user) {


### PR DESCRIPTION
## Summary

Fixes a crash when accessing files from USB storage (USB key, external drive) on Switch, plus a follow-up thread-safety hardening of the UMS device callback.

## Crash root cause

`Filesystem::name` and `Filesystem::mount_name` ([src/fs/fs_common.hpp](https://github.com/averne/SwitchWave/blob/master/src/fs/fs_common.hpp)) are `std::string_view`. For USB devices, those views point into `std::string` members of `UmsController::Device`.

libusbhsfs's populate callback (`UmsController::usbhsfs_populate_cb`) does `self->devices.clear()` then re-populates on every event — partition discovery, mount, unmount. That destroys the strings the existing `Filesystem` views reference, leaving them dangling. Subsequent file access via `mount_name.data()` (e.g. through devoptab lookup) triggers a use-after-free and crashes.

## Fixes in this PR

**1. Own the strings (commit 1)**
- `Filesystem::name` / `mount_name` now own their strings (`std::string` instead of `std::string_view`). USB `Filesystem` instances survive `UmsController::devices.clear()`. The C++23 build (`gnu++23`) makes the existing `this->name = sv` assignments in network FS subclasses still compile unchanged.
- `ums_devices_changed_cb` no longer calls `std::erase` on `context.filesystems` while range-iterating it (was UB). Switched to `std::erase_if`, and `cur_fs` is only reset when it actually pointed to a removed device.

**2. Defer UMS updates to the main thread (commit 2)**
- libusbhsfs invokes the populate callback on its USB-event thread, which previously mutated `context.filesystems` / `cur_fs` while main-thread UI code was reading them. The callback now only stashes a pending device list under a mutex; `apply_pending_ums_changes` drains and applies it once per frame from `menu_loop` and `video_loop`, keeping `context.filesystems` single-threaded for readers.
- When the filesystem hosting the currently-playing file disappears (USB unplugged mid-playback), async-stop mpv and break out of `video_loop` with `EIO` so the user falls back to the menu cleanly.

## Test plan

- [x] Built and tested on real Switch hardware.
- [x] USB-key file access no longer crashes.
- [x] Unplug while in the menu: device cleanly disappears from the list, currently-listed files become inaccessible with a clean error rather than a crash.
- [x] Unplug while paused / between reads in playback: drops back to menu cleanly.
- [x] Network filesystems and SD card unaffected (regression check).

## Known remaining limitation

Physical USB removal *while mpv's demuxer thread is mid-read* still crashes inside libusbhsfs's internal teardown — that race lives below SwitchWave and would require upstream changes in libusbhsfs to defer cleanup until in-flight reads drain. Not addressed here.